### PR TITLE
Initialize frontend and backend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ ChatGPT (Codex/Custom GPT)
 - /backend   (Go, Fiber or Chi)
 - /shared    (APIスキーマ定義, JSON Schema)
 
+`/frontend`, `/backend`, `/shared` ディレクトリを作成し、最小構成のアプリケーションを配置しています。
+
 🗺️ 機能一覧と実装順序
 
 ステージ1：MVPフェーズ

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,3 @@
+module potarin-backend
+
+go 1.23.8

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"github.com/gofiber/fiber/v2"
+)
+
+func main() {
+	app := fiber.New()
+
+	app.Get("/api/v1/suggestions", func(c *fiber.Ctx) error {
+		return c.JSON(fiber.Map{"message": "suggestions placeholder"})
+	})
+
+	app.Get("/api/v1/details", func(c *fiber.Ctx) error {
+		return c.JSON(fiber.Map{"message": "details placeholder"})
+	})
+
+	app.Listen(":8080")
+}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,3 @@
+# Frontend
+
+This directory contains the Next.js application.

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,13 @@
+import './styles/globals.css';
+
+export const metadata = {
+  title: 'Potarin',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="ja">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div className="p-4">Hello Potarin</div>;
+}

--- a/frontend/app/styles/globals.css
+++ b/frontend/app/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "potarin-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.4",
+    "react": "18.3.0",
+    "react-dom": "18.3.0"
+  },
+  "devDependencies": {
+    "typescript": "5.4.5",
+    "tailwindcss": "3.4.4",
+    "postcss": "8.4.31",
+    "autoprefixer": "10.4.16"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.js"],
+  "exclude": ["node_modules"]
+}

--- a/shared/README.md
+++ b/shared/README.md
@@ -1,0 +1,3 @@
+# Shared
+
+Shared schemas and types will live here.


### PR DESCRIPTION
## Summary
- set up `/backend` Go module with basic Fiber server
- create Next.js skeleton in `/frontend`
- add shared directory and update main README

## Testing
- `go build ./...` *(fails: module downloads blocked)*
- `npm install` in `frontend` *(fails: access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684576028804832fae40fca7c37e62a8