### PR TITLE
Define shared API types and update backend

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,3 +1,10 @@
 module potarin-backend
 
 go 1.23.8
+
+require (
+    github.com/gofiber/fiber/v2 v2.50.2
+    potarin-shared v0.0.0
+)
+
+replace potarin-shared => ../shared

--- a/backend/main.go
+++ b/backend/main.go
@@ -2,17 +2,37 @@ package main
 
 import (
 	"github.com/gofiber/fiber/v2"
+	shared "potarin-shared"
 )
 
 func main() {
 	app := fiber.New()
 
 	app.Get("/api/v1/suggestions", func(c *fiber.Ctx) error {
-		return c.JSON(fiber.Map{"message": "suggestions placeholder"})
+		suggestions := []shared.Suggestion{
+			{ID: "1", Title: "River Side Ride", Description: "Enjoy the river view."},
+			{ID: "2", Title: "City Exploration", Description: "Discover downtown."},
+		}
+		return c.JSON(suggestions)
 	})
 
 	app.Get("/api/v1/details", func(c *fiber.Ctx) error {
-		return c.JSON(fiber.Map{"message": "details placeholder"})
+		details := shared.Detail{
+			Summary: "River Side Ride details",
+			Routes: []shared.Route{
+				{
+					Title:       "Start Point",
+					Description: "Park",
+					Position:    shared.Position{Lat: 35.0, Lng: 135.0},
+				},
+				{
+					Title:       "End Point",
+					Description: "Bridge",
+					Position:    shared.Position{Lat: 35.1, Lng: 135.1},
+				},
+			},
+		}
+		return c.JSON(details)
 	})
 
 	app.Listen(":8080")

--- a/shared/go.mod
+++ b/shared/go.mod
@@ -1,0 +1,3 @@
+module potarin-shared
+
+go 1.23.8

--- a/shared/types.go
+++ b/shared/types.go
@@ -1,0 +1,27 @@
+package shared
+
+// Suggestion represents a simple course suggestion.
+type Suggestion struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+}
+
+// Position represents a geo coordinate.
+type Position struct {
+	Lat float64 `json:"lat"`
+	Lng float64 `json:"lng"`
+}
+
+// Route represents part of a course with a position.
+type Route struct {
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Position    Position `json:"position"`
+}
+
+// Detail represents detailed course information.
+type Detail struct {
+	Summary string  `json:"summary"`
+	Routes  []Route `json:"routes"`
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,0 +1,21 @@
+export interface Suggestion {
+  id: string;
+  title: string;
+  description: string;
+}
+
+export interface Position {
+  lat: number;
+  lng: number;
+}
+
+export interface Route {
+  title: string;
+  description: string;
+  position: Position;
+}
+
+export interface Detail {
+  summary: string;
+  routes: Route[];
+}


### PR DESCRIPTION
## Summary
- add `shared` module with common API types for suggestions and details
- serve sample JSON responses using those types in Fiber handlers
- link backend to the shared module

## Testing
- `go build ./...` *(fails: missing go.sum entry for github.com/gofiber/fiber/v2)*
- `npx tsc --noEmit -p frontend/tsconfig.json` *(fails: Cannot find namespace 'React')*


------
https://chatgpt.com/codex/tasks/task_e_684576f06e80832f93e3aaaac19971d9