### PR TITLE
[Potarin] Add frontend pages for course suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,110 +6,152 @@
 このバージョンでは、AIエージェント（Codex等）を積極活用しながら、バックエンドをGo言語で完全再設計します。
 
 ## 利用技術スタック
+
 採用技術
+
 ### フロントエンド
+
 Next.js 14 (App Router, TypeScript, React 18)
 bun
 
 ### バックエンド
+
 Golang
 
 ### AI連携
+
 OpenAI GPT-4o / GPT-4o-mini API
 
 ### 地図描画
+
 React-Leaflet + Leaflet
+
 ### スタイリング
+
 Tailwind CSS
+
 ### ビルド・開発
+
 Bun (フロント用) / Go modules
+
 ### デプロイ
+
 Vercel (フロント), Fly.io or Railway (Goバックエンド)
+
 ### 状態管理
+
 React Context or Zustand
+
 ### API通信
+
 REST + JSON
+
 ### CI/CD
+
 GitHub Actions
+
 ### AI開発支援
+
 ChatGPT (Codex/Custom GPT)
 
 ## ディレクトリ構成
 
-- /frontend  (Next.js, TypeScript, React)
-- /backend   (Go, Fiber or Chi)
-- /shared    (APIスキーマ定義, JSON Schema)
+- /frontend (Next.js, TypeScript, React)
+- /backend (Go, Fiber or Chi)
+- /shared (APIスキーマ定義, JSON Schema)
 
 `/frontend`, `/backend`, `/shared` ディレクトリを作成し、最小構成のアプリケーションを配置しています。
+
+## クイックスタート
+
+1. `backend` ディレクトリで Go サーバーを起動
+
+```bash
+cd backend
+go run .
+```
+
+2. 別ターミナルで `frontend` を起動
+
+```bash
+cd frontend
+bun run dev
+```
+
+環境変数 `NEXT_PUBLIC_API_URL` を設定すると、フロントエンドが参照する API サーバー URL を変更できます。
 
 ## 機能一覧と実装順序
 
 ### ステージ1：MVPフェーズ
 
 ✅ プロジェクト初期化
-	•	frontend：bunx create-next-app + Tailwind + TypeScript構成
-	•	backend：go mod init potarin-backend + Fiber or Chi
+• frontend：bunx create-next-app + Tailwind + TypeScript構成
+• backend：go mod init potarin-backend + Fiber or Chi
 
 ✅ API設計 (Go)
-	•	/api/v1/suggestions  (AI提案エンドポイント)
-	•	入力: ユーザーリクエスト (天候・希望コースタイプ等)
-	•	出力: JSONスキーマに準拠したAI提案コース群
-	•	/api/v1/details (コース詳細エンドポイント)
-	•	入力: 選択されたコース概要
-	•	出力: コース詳細 (waypoints + 位置情報含む)
+• /api/v1/suggestions (AI提案エンドポイント)
+• 入力: ユーザーリクエスト (天候・希望コースタイプ等)
+• 出力: JSONスキーマに準拠したAI提案コース群
+• /api/v1/details (コース詳細エンドポイント)
+• 入力: 選択されたコース概要
+• 出力: コース詳細 (waypoints + 位置情報含む)
 
 ✅ AIプロンプト設計 (Codex駆動)
-	•	Goサーバー内でプロンプト＋JSONスキーマによるresponse_format利用
-	•	型安全なOpenAI応答処理（Goでは非常に強力）
+• Goサーバー内でプロンプト＋JSONスキーマによるresponse_format利用
+• 型安全なOpenAI応答処理（Goでは非常に強力）
 
 ✅ フロント実装
-	•	ヘッダー / カード型コース提案表示
-	•	コース選択→詳細画面遷移
-	•	地図表示 (MapClient SSR排除)
-	•	Mapに出発地点のみマーカー描画
+• ヘッダー / カード型コース提案表示
+• コース選択→詳細画面遷移
+• 地図表示 (MapClient SSR排除)
+• Mapに出発地点のみマーカー描画
 
 ⸻
 
 ### ステージ2：AI詳細化・ルート描画フェーズ
 
 ✅ 詳細APIの拡張
--	AIからsummary + routes[{title, description, position}]を受信
+
+- AIからsummary + routes[{title, description, position}]を受信
 
 ✅ 地図描画
--	複数マーカー描画
--	Polyline描画によるルート可視化
 
-✅ エージェントAPIの段階的投入
-	-	OpenAI Functions API利用可能なら、Go側でエージェントスキーマ登録
-	-	CodexによるAPIスキーマ検証補助
+- 複数マーカー描画
+- Polyline描画によるルート可視化
+
+✅ エージェントAPIの段階的投入 - OpenAI Functions API利用可能なら、Go側でエージェントスキーマ登録 - CodexによるAPIスキーマ検証補助
 
 ### ステージ3：拡張フェーズ
 
--	運動量・距離制御オプション追加
--	ユーザー現在地(GPS)サポート
--	天候API連携
--	履歴保存・再利用機能（SQLite, PostgreSQL）
+- 運動量・距離制御オプション追加
+- ユーザー現在地(GPS)サポート
+- 天候API連携
+- 履歴保存・再利用機能（SQLite, PostgreSQL）
 
 ### 設計・実装の注意点
 
 #### AIプロンプト設計上の注意
--	JSONスキーマを必ずAIに渡す (response_format: json_schema)
--	一切自然文レスポンスさせない (Goのパース強靭性が最大限活きる)
+
+- JSONスキーマを必ずAIに渡す (response_format: json_schema)
+- 一切自然文レスポンスさせない (Goのパース強靭性が最大限活きる)
 
 #### Goバックエンド設計上の注意
--	Fiber (またはChi) を使った軽量APIサーバー
--	全APIは JSON POST/GETのみ（OpenAPIスキーマで定義可）
--	OpenAIエラーハンドリングはpanicせず安全に戻す
--	型安全のために明示的な構造体定義を使う
+
+- Fiber (またはChi) を使った軽量APIサーバー
+- 全APIは JSON POST/GETのみ（OpenAPIスキーマで定義可）
+- OpenAIエラーハンドリングはpanicせず安全に戻す
+- 型安全のために明示的な構造体定義を使う
 
 #### フロント実装注意
--	MapClientは必ずdynamic(..., { ssr: false })でSSR除外
--	API通信時の型はsharedディレクトリからimportして厳密に管理
--	Codexを使ってAPIスキーマ→型定義生成も可能
+
+- MapClientは必ずdynamic(..., { ssr: false })でSSR除外
+- API通信時の型はsharedディレクトリからimportして厳密に管理
+- Codexを使ってAPIスキーマ→型定義生成も可能
 
 ## 完成イメージ
--	AIが実時間で適切なサイクリングコースを提案
--	地図上にルートを動的に描画
--	ユーザーは距離・気分・天候を指定可能
--	バックエンドはGoが堅牢にAPI連携を処理
--	開発はCodexエージェントが随時補助
+
+- AIが実時間で適切なサイクリングコースを提案
+- 地図上にルートを動的に描画
+- ユーザーは距離・気分・天候を指定可能
+- バックエンドはGoが堅牢にAPI連携を処理
+- 開発はCodexエージェントが随時補助

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,13 +1,24 @@
-import './styles/globals.css';
+import "./styles/globals.css";
 
 export const metadata = {
-  title: 'Potarin',
+  title: "Potarin",
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
     <html lang="ja">
-      <body>{children}</body>
+      <body>
+        <header className="p-4 bg-gray-100 mb-4">
+          <a href="/" className="font-bold">
+            Potarin
+          </a>
+        </header>
+        {children}
+      </body>
     </html>
   );
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,3 +1,35 @@
-export default function Home() {
-  return <div className="p-4">Hello Potarin</div>;
+import { Suggestion } from "potarin-shared/types";
+
+async function getSuggestions(): Promise<Suggestion[]> {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080"}/api/v1/suggestions`,
+    { cache: "no-store" },
+  );
+  if (!res.ok) {
+    throw new Error("Failed to fetch suggestions");
+  }
+  return res.json();
+}
+
+export default async function Home() {
+  const suggestions = await getSuggestions();
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Course Suggestions</h1>
+      <ul className="grid gap-4">
+        {suggestions.map((s) => (
+          <li key={s.id} className="border p-4 rounded">
+            <a
+              href={`/suggestions/${s.id}`}
+              className="text-blue-600 hover:underline"
+            >
+              {s.title}
+            </a>
+            <p className="text-sm text-gray-600">{s.description}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }

--- a/frontend/app/suggestions/[id]/page.tsx
+++ b/frontend/app/suggestions/[id]/page.tsx
@@ -1,13 +1,15 @@
 import { Detail } from "potarin-shared/types";
 
 interface Params {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
 async function getDetail(id: string): Promise<Detail> {
   const res = await fetch(
-    `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080"}/api/v1/details?id=${id}`,
-    { cache: "no-store" },
+    `${
+      process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080"
+    }/api/v1/details?id=${id}`,
+    { cache: "no-store" }
   );
   if (!res.ok) {
     throw new Error("Failed to fetch detail");
@@ -16,7 +18,8 @@ async function getDetail(id: string): Promise<Detail> {
 }
 
 export default async function SuggestionDetail({ params }: Params) {
-  const detail = await getDetail(params.id);
+  const { id } = await params;
+  const detail = await getDetail(id);
 
   return (
     <div className="p-4">

--- a/frontend/app/suggestions/[id]/page.tsx
+++ b/frontend/app/suggestions/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { Detail } from "potarin-shared/types";
 
 interface Params {
-  params: Promise<{ id: string }>;
+  params: { id: string };
 }
 
 async function getDetail(id: string): Promise<Detail> {

--- a/frontend/app/suggestions/[id]/page.tsx
+++ b/frontend/app/suggestions/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { Detail } from "potarin-shared/types";
 
 interface Params {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
 async function getDetail(id: string): Promise<Detail> {

--- a/frontend/app/suggestions/[id]/page.tsx
+++ b/frontend/app/suggestions/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { Detail } from "potarin-shared/types";
 
 interface Params {
-  params: Promise<{ id: string }>;
+  params: { id: string };
 }
 
 async function getDetail(id: string): Promise<Detail> {
@@ -16,8 +16,7 @@ async function getDetail(id: string): Promise<Detail> {
 }
 
 export default async function SuggestionDetail({ params }: Params) {
-  const { id } = await params;
-  const detail = await getDetail(id);
+  const detail = await getDetail(params.id);
 
   return (
     <div className="p-4">

--- a/frontend/app/suggestions/[id]/page.tsx
+++ b/frontend/app/suggestions/[id]/page.tsx
@@ -1,0 +1,34 @@
+import { Detail } from "potarin-shared/types";
+
+interface Params {
+  params: { id: string };
+}
+
+async function getDetail(id: string): Promise<Detail> {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080"}/api/v1/details?id=${id}`,
+    { cache: "no-store" },
+  );
+  if (!res.ok) {
+    throw new Error("Failed to fetch detail");
+  }
+  return res.json();
+}
+
+export default async function SuggestionDetail({ params }: Params) {
+  const detail = await getDetail(params.id);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">{detail.summary}</h1>
+      <ul className="space-y-2">
+        {detail.routes.map((r, index) => (
+          <li key={index} className="border p-2 rounded">
+            <strong>{r.title}</strong> - {r.description} ({r.position.lat},{" "}
+            {r.position.lng})
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/app/suggestions/[id]/page.tsx
+++ b/frontend/app/suggestions/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { Detail } from "potarin-shared/types";
 
 interface Params {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
 async function getDetail(id: string): Promise<Detail> {
@@ -16,7 +16,8 @@ async function getDetail(id: string): Promise<Detail> {
 }
 
 export default async function SuggestionDetail({ params }: Params) {
-  const detail = await getDetail(params.id);
+  const { id } = await params;
+  const detail = await getDetail(id);
 
   return (
     <div className="p-4">

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -15,6 +11,10 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
+    "baseUrl": ".",
+    "paths": {
+      "potarin-shared/*": ["../shared/*"]
+    },
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
@@ -31,7 +31,5 @@
     "next-env.d.ts",
     ".next/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- fetch suggestions in the homepage
- add detail page for each suggestion
- show simple header
- document a quick start guide
- configure TS paths for shared types

## Testing
- `gofmt -w main.go && go build ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*
- `bun install` *(fails: 403 errors)*
- `bun run build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684586120690832f86fab2f115e6a1fd