### PR TITLE
[Potarin] display suggestions from backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:8080

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .next/
+backend/potarin-backend

--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ ChatGPT (Codex/Custom GPT)
 
 `/frontend`, `/backend`, `/shared` ディレクトリを作成し、最小構成のアプリケーションを配置しています。
 
+## 開発の始め方
+
+1. `cp frontend/.env.local.example frontend/.env.local` を実行し、必要に応じて `NEXT_PUBLIC_API_URL` を編集します。
+2. Go サーバーを起動します。
+   ```bash
+   cd backend
+   go run main.go
+   ```
+3. フロントエンドを起動します。
+   ```bash
+   cd frontend
+   bun run dev
+   ```
+
 ## 機能一覧と実装順序
 
 ### ステージ1：MVPフェーズ

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:8080

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,3 +1,27 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { Suggestion } from "../../shared/types";
+
 export default function Home() {
-  return <div className="p-4">Hello Potarin</div>;
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+
+  useEffect(() => {
+    const base = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
+    fetch(`${base}/api/v1/suggestions`)
+      .then((res) => res.json())
+      .then((data: Suggestion[]) => setSuggestions(data))
+      .catch((err) => console.error(err));
+  }, []);
+
+  return (
+    <div className="p-4 space-y-2">
+      {suggestions.map((s) => (
+        <div key={s.id} className="border p-2 rounded">
+          <h2 className="font-bold">{s.title}</h2>
+          <p>{s.description}</p>
+        </div>
+      ))}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add examples for environment variables
- show how to run the backend and frontend
- ignore compiled backend binaries
- fetch and display suggestions on the Next.js home page

## Testing
- `go build ./...`
- `go test ./...`
- `bun install`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68458a8b839c832f90aa1cf3bea354b2