### PR TITLE
[Potarin] add openai endpoint

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your_api_key_here

--- a/.env.local
+++ b/.env.local
@@ -1,1 +1,0 @@
-OPENAI_API_KEY=your_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 dist/
 .next/
+.env.local
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules/
 dist/
 .next/
-.env.local
+/.env.local
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ bun run dev
 ```
 
 環境変数 `NEXT_PUBLIC_API_URL` を設定すると、フロントエンドが参照する API サーバー URL を変更できます。
+バックエンドで OpenAI を利用する場合は、プロジェクトルートの `.env.local` に `OPENAI_API_KEY` を設定してください。
 
 ## 機能一覧と実装順序
 

--- a/backend/internal/openai.go
+++ b/backend/internal/openai.go
@@ -1,0 +1,103 @@
+package internal
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+type Client struct {
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
+}
+
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type ResponseFormat struct {
+	Type string `json:"type"`
+}
+
+type ChatRequest struct {
+	Model          string         `json:"model"`
+	Messages       []Message      `json:"messages"`
+	ResponseFormat ResponseFormat `json:"response_format"`
+}
+
+type chatResponse struct {
+	Choices []struct {
+		Message Message `json:"message"`
+	} `json:"choices"`
+}
+
+// LoadEnv loads environment variables from .env.local if present.
+func LoadEnv() {
+	f, err := os.Open(".env.local")
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) == 2 {
+			os.Setenv(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]))
+		}
+	}
+}
+
+// NewClient creates a new OpenAI client using environment variables.
+func NewClient() *Client {
+	return &Client{
+		apiKey:     os.Getenv("OPENAI_API_KEY"),
+		baseURL:    "https://api.openai.com",
+		httpClient: &http.Client{},
+	}
+}
+
+// Chat sends a chat completion request and returns the first message content.
+func (c *Client) Chat(ctx context.Context, req ChatRequest) (string, error) {
+	b, err := json.Marshal(req)
+	if err != nil {
+		return "", err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/chat/completions", bytes.NewReader(b))
+	if err != nil {
+		return "", err
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", errors.New(string(body))
+	}
+	var res chatResponse
+	if err := json.Unmarshal(body, &res); err != nil {
+		return "", err
+	}
+	if len(res.Choices) == 0 {
+		return "", errors.New("no choices returned")
+	}
+	return res.Choices[0].Message.Content, nil
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -68,7 +68,7 @@ func fetchDetail(ctx context.Context, ai *internal.Client, id string) (shared.De
 	req := internal.ChatRequest{
 		Model: "gpt-4o",
 		Messages: []internal.Message{
-			{Role: "system", Content: "Return course detail as JSON." + schema},
+			{Role: "system", Content: "Return course detail as JSON.\n" + schema},
 			{Role: "user", Content: fmt.Sprintf("detail for course %s", id)},
 		},
 		ResponseFormat: internal.ResponseFormat{Type: "json_object"},

--- a/backend/main.go
+++ b/backend/main.go
@@ -45,7 +45,7 @@ func fetchSuggestions(ctx context.Context, ai *internal.Client) ([]shared.Sugges
 	req := internal.ChatRequest{
 		Model: "gpt-4o",
 		Messages: []internal.Message{
-			{Role: "system", Content: "Return course suggestions as JSON." + schema},
+			{Role: "system", Content: "Return course suggestions as JSON.\n" + schema},
 			{Role: "user", Content: "Please suggest some courses."},
 		},
 		ResponseFormat: internal.ResponseFormat{Type: "json_object"},

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,41 +1,85 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+
 	"github.com/gofiber/fiber/v2"
+	"potarin-backend/internal"
 	shared "potarin-shared"
 )
 
 func main() {
+	internal.LoadEnv()
+	ai := internal.NewClient()
 	app := fiber.New()
 
 	app.Get("/api/v1/suggestions", func(c *fiber.Ctx) error {
-		suggestions := []shared.Suggestion{
-			{ID: "1", Title: "River Side Ride", Description: "Enjoy the river view."},
-			{ID: "2", Title: "City Exploration", Description: "Discover downtown."},
+		suggestions, err := fetchSuggestions(c.Context(), ai)
+		if err != nil {
+			return fiber.NewError(fiber.StatusInternalServerError, err.Error())
 		}
 		return c.JSON(suggestions)
 	})
 
 	app.Get("/api/v1/details", func(c *fiber.Ctx) error {
-		details := shared.Detail{
-			Summary: "River Side Ride details",
-			Routes: []shared.Route{
-				{
-					Title:       "Start Point",
-					Description: "Park",
-					Position:    shared.Position{Lat: 35.0, Lng: 135.0},
-				},
-				{
-					Title:       "End Point",
-					Description: "Bridge",
-					Position:    shared.Position{Lat: 35.1, Lng: 135.1},
-				},
-			},
+		id := c.Query("id")
+		if id == "" {
+			return fiber.NewError(fiber.StatusBadRequest, "id required")
 		}
-		return c.JSON(details)
+		detail, err := fetchDetail(c.Context(), ai, id)
+		if err != nil {
+			return fiber.NewError(fiber.StatusInternalServerError, err.Error())
+		}
+		return c.JSON(detail)
 	})
 
 	if err := app.Listen(":8080"); err != nil {
 		panic(err)
 	}
+}
+
+func fetchSuggestions(ctx context.Context, ai *internal.Client) ([]shared.Suggestion, error) {
+	schema := `{"type":"object","properties":{"suggestions":{"type":"array","items":{"type":"object","properties":{"id":{"type":"string"},"title":{"type":"string"},"description":{"type":"string"}},"required":["id","title","description"]}}},"required":["suggestions"]}`
+	req := internal.ChatRequest{
+		Model: "gpt-4o",
+		Messages: []internal.Message{
+			{Role: "system", Content: "Return course suggestions as JSON." + schema},
+			{Role: "user", Content: "Please suggest some courses."},
+		},
+		ResponseFormat: internal.ResponseFormat{Type: "json_object"},
+	}
+	content, err := ai.Chat(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	var parsed struct {
+		Suggestions []shared.Suggestion `json:"suggestions"`
+	}
+	if err := json.Unmarshal([]byte(content), &parsed); err != nil {
+		return nil, err
+	}
+	return parsed.Suggestions, nil
+}
+
+func fetchDetail(ctx context.Context, ai *internal.Client, id string) (shared.Detail, error) {
+	schema := `{"type":"object","properties":{"summary":{"type":"string"},"routes":{"type":"array","items":{"type":"object","properties":{"title":{"type":"string"},"description":{"type":"string"},"position":{"type":"object","properties":{"lat":{"type":"number"},"lng":{"type":"number"}},"required":["lat","lng"]}},"required":["title","description","position"]}}},"required":["summary","routes"]}`
+	req := internal.ChatRequest{
+		Model: "gpt-4o",
+		Messages: []internal.Message{
+			{Role: "system", Content: "Return course detail as JSON." + schema},
+			{Role: "user", Content: fmt.Sprintf("detail for course %s", id)},
+		},
+		ResponseFormat: internal.ResponseFormat{Type: "json_object"},
+	}
+	content, err := ai.Chat(ctx, req)
+	if err != nil {
+		return shared.Detail{}, err
+	}
+	var detail shared.Detail
+	if err := json.Unmarshal([]byte(content), &detail); err != nil {
+		return shared.Detail{}, err
+	}
+	return detail, nil
 }


### PR DESCRIPTION
## Summary
- implement OpenAI client and env loader
- add AI-backed endpoints for course suggestions and details
- document `OPENAI_API_KEY` in README

## Testing
- `go build ./...`
- `go test ./...`
- `bun install`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68481a5b5f14832fb2707d5e5d0a4e33