### PR TITLE
[Potarin] Add Go unit tests

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -61,7 +61,11 @@ func main() {
 	}
 }
 
-func fetchSuggestions(ctx context.Context, ai *internal.Client, userPrompt string) ([]shared.Suggestion, error) {
+type AIClient interface {
+	Chat(ctx context.Context, req internal.ChatRequest) (string, error)
+}
+
+func fetchSuggestions(ctx context.Context, ai AIClient, userPrompt string) ([]shared.Suggestion, error) {
 	userProf, err := json.Marshal(userProfile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal user profile: %w", err)
@@ -95,7 +99,7 @@ func fetchSuggestions(ctx context.Context, ai *internal.Client, userPrompt strin
 	return parsed.Suggestions, nil
 }
 
-func fetchDetail(ctx context.Context, ai *internal.Client, suggestion shared.Suggestion) (shared.Detail, error) {
+func fetchDetail(ctx context.Context, ai AIClient, suggestion shared.Suggestion) (shared.Detail, error) {
 	schema := `{"type":"object","properties":{"summary":{"type":"string"},"routes":{"type":"array","items":{"type":"object","properties":{"title":{"type":"string"},"description":{"type":"string"},"position":{"type":"object","properties":{"lat":{"type":"number"},"lng":{"type":"number"}},"required":["lat","lng"]}},"required":["title","description","position"]}}},"required":["summary","routes"]}`
 	userPrompt := fmt.Sprintf("タイトル: %s\n説明: %s\nこのコースの詳細を教えてください。", suggestion.Title, suggestion.Description)
 	req := internal.ChatRequest{

--- a/backend/main_test.go
+++ b/backend/main_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"potarin-backend/internal"
+	shared "potarin-shared"
+)
+
+type mockClient struct {
+	response string
+	err      error
+}
+
+func (m mockClient) Chat(ctx context.Context, req internal.ChatRequest) (string, error) {
+	return m.response, m.err
+}
+
+func TestFetchSuggestionsSuccess(t *testing.T) {
+	mc := mockClient{response: `{"suggestions":[{"id":"1","title":"Course","description":"Desc"}]}`}
+	got, err := fetchSuggestions(context.Background(), mc, "")
+	if err != nil {
+		t.Fatalf("fetchSuggestions returned error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 suggestion, got %d", len(got))
+	}
+	if got[0].ID != "1" || got[0].Title != "Course" {
+		t.Fatalf("unexpected suggestion: %+v", got[0])
+	}
+}
+
+func TestFetchSuggestionsInvalidJSON(t *testing.T) {
+	mc := mockClient{response: `invalid`}
+	if _, err := fetchSuggestions(context.Background(), mc, ""); err == nil {
+		t.Fatal("expected error from invalid JSON")
+	}
+}
+
+func TestFetchDetailSuccess(t *testing.T) {
+	resp := `{"summary":"sum","routes":[{"title":"t","description":"d","position":{"lat":1,"lng":2}}]}`
+	mc := mockClient{response: resp}
+	sug := shared.Suggestion{ID: "1", Title: "t", Description: "d"}
+	got, err := fetchDetail(context.Background(), mc, sug)
+	if err != nil {
+		t.Fatalf("fetchDetail returned error: %v", err)
+	}
+	if got.Summary != "sum" || len(got.Routes) != 1 {
+		t.Fatalf("unexpected detail: %+v", got)
+	}
+	if got.Routes[0].Position.Lat != 1 || got.Routes[0].Position.Lng != 2 {
+		t.Fatalf("unexpected position: %+v", got.Routes[0].Position)
+	}
+}
+
+func TestFetchDetailInvalidJSON(t *testing.T) {
+	mc := mockClient{response: `invalid`}
+	sug := shared.Suggestion{}
+	if _, err := fetchDetail(context.Background(), mc, sug); err == nil {
+		t.Fatal("expected error from invalid JSON")
+	}
+}


### PR DESCRIPTION
## Summary
- refactor backend functions to accept AIClient interface
- add unit tests for `fetchSuggestions` and `fetchDetail`

## Testing
- `go build ./...`
- `go test ./...`
- `bun install`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_6848cd2cb180832fa6b7afeab1e9c443