### PR TITLE
[Potarin] Add API key validation

### DIFF
--- a/backend/internal/openai.go
+++ b/backend/internal/openai.go
@@ -51,12 +51,17 @@ func LoadEnv() {
 }
 
 // NewClient creates a new OpenAI client using environment variables.
-func NewClient() *Client {
+// It returns an error if the API key is empty.
+func NewClient() (*Client, error) {
+	key := os.Getenv("OPENAI_API_KEY")
+	if key == "" {
+		return nil, fmt.Errorf("OPENAI_API_KEY is not set")
+	}
 	return &Client{
-		apiKey:     os.Getenv("OPENAI_API_KEY"),
+		apiKey:     key,
 		baseURL:    "https://api.openai.com",
 		httpClient: &http.Client{},
-	}
+	}, nil
 }
 
 // Chat sends a chat completion request and returns the first message content.

--- a/backend/internal/openai_test.go
+++ b/backend/internal/openai_test.go
@@ -55,9 +55,11 @@ func TestChatError(t *testing.T) {
 	if err.Error() != "bad request" {
 		t.Fatalf("unexpected error: %v", err)
 	}
-  func TestNewClientEmptyKey(t *testing.T) {
+}
+func TestNewClientEmptyKey(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "")
 	if _, err := NewClient(); err == nil {
 		t.Fatal("expected error when API key is empty")
 
+	}
 }

--- a/backend/internal/openai_test.go
+++ b/backend/internal/openai_test.go
@@ -1,0 +1,10 @@
+package internal
+
+import "testing"
+
+func TestNewClientEmptyKey(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	if _, err := NewClient(); err == nil {
+		t.Fatal("expected error when API key is empty")
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 
 	"potarin-backend/internal"
 	shared "potarin-shared"

--- a/backend/main.go
+++ b/backend/main.go
@@ -31,7 +31,11 @@ var userProfile = UserProfile{
 
 func main() {
 	internal.LoadEnv()
-	ai := internal.NewClient()
+	ai, err := internal.NewClient()
+	if err != nil {
+		fmt.Printf("failed to create OpenAI client: %v\n", err)
+		return
+	}
 	app := fiber.New()
 	app.Use(cors.New())
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -34,7 +34,7 @@ func main() {
 	ai, err := internal.NewClient()
 	if err != nil {
 		fmt.Printf("failed to create OpenAI client: %v\n", err)
-		return
+		os.Exit(1)
 	}
 	app := fiber.New()
 	app.Use(cors.New())

--- a/backend/main.go
+++ b/backend/main.go
@@ -33,8 +33,7 @@ func main() {
 	internal.LoadEnv()
 	ai, err := internal.NewClient()
 	if err != nil {
-		fmt.Printf("failed to create OpenAI client: %v\n", err)
-		os.Exit(1)
+		log.Fatalf("failed to create OpenAI client: %v", err)
 	}
 	app := fiber.New()
 	app.Use(cors.New())


### PR DESCRIPTION
## Summary
- validate the OPENAI_API_KEY in NewClient
- handle the error when creating the client
- add a test for empty API key failure

## Testing
- `go build ./...`
- `go test ./...`
- `bun install`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68495f536594832f8eecd8a894d67d17