### PR TITLE
[Potarin] Add Leaflet map

### DIFF
--- a/frontend/app/components/MapClient.tsx
+++ b/frontend/app/components/MapClient.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { MapContainer, TileLayer, Marker, Polyline } from "react-leaflet";
+import type { Route } from "potarin-shared/types";
+import "leaflet/dist/leaflet.css";
+
+function LeafletMap({ routes }: { routes: Route[] }) {
+  const positions = routes.map((r) => [r.position.lat, r.position.lng] as [number, number]);
+  const center = positions[0] ?? [0, 0];
+  return (
+    <MapContainer center={center} zoom={13} className="h-96 w-full mb-4">
+      <TileLayer
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        attribution="&copy; OpenStreetMap contributors"
+      />
+      {positions.map((pos, idx) => (
+        <Marker key={idx} position={pos} />
+      ))}
+      {positions.length > 1 && <Polyline positions={positions} />}
+    </MapContainer>
+  );
+}
+
+export default dynamic(() => Promise.resolve(LeafletMap), { ssr: false });

--- a/frontend/app/suggestions/[id]/page.tsx
+++ b/frontend/app/suggestions/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { Detail, Suggestion } from "potarin-shared/types";
+import MapClient from "../../components/MapClient";
 
 async function getSuggestions(): Promise<Suggestion[]> {
   const res = await fetch(
@@ -45,6 +46,7 @@ export default async function SuggestionDetail({
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-4">{detail.summary}</h1>
+      <MapClient routes={detail.routes} />
       <ul className="space-y-2">
         {detail.routes.map((r, index) => (
           <li key={index} className="border p-2 rounded">

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -5,9 +5,11 @@
       "name": "potarin-frontend",
       "dependencies": {
         "@tailwindcss/postcss": "^4.1.8",
+        "leaflet": "^1.9.4",
         "next": "15.3.3",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "react-leaflet": "^4.2.1",
       },
       "devDependencies": {
         "@types/node": "^22.15.30",
@@ -141,6 +143,8 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
+
+    "@react-leaflet/core": ["@react-leaflet/core@2.1.0", "", { "peerDependencies": { "leaflet": "^1.9.0", "react": "^18.0.0", "react-dom": "^18.0.0" } }, "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg=="],
 
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
@@ -562,6 +566,8 @@
 
     "language-tags": ["language-tags@1.0.9", "", { "dependencies": { "language-subtag-registry": "^0.3.20" } }, "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA=="],
 
+    "leaflet": ["leaflet@1.9.4", "", {}, "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="],
+
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
     "lightningcss": ["lightningcss@1.30.1", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-darwin-arm64": "1.30.1", "lightningcss-darwin-x64": "1.30.1", "lightningcss-freebsd-x64": "1.30.1", "lightningcss-linux-arm-gnueabihf": "1.30.1", "lightningcss-linux-arm64-gnu": "1.30.1", "lightningcss-linux-arm64-musl": "1.30.1", "lightningcss-linux-x64-gnu": "1.30.1", "lightningcss-linux-x64-musl": "1.30.1", "lightningcss-win32-arm64-msvc": "1.30.1", "lightningcss-win32-x64-msvc": "1.30.1" } }, "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg=="],
@@ -679,6 +685,8 @@
     "react-dom": ["react-dom@19.1.0", "", { "dependencies": { "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.0" } }, "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g=="],
 
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "react-leaflet": ["react-leaflet@4.2.1", "", { "dependencies": { "@react-leaflet/core": "^2.1.0" }, "peerDependencies": { "leaflet": "^1.9.0", "react": "^18.0.0", "react-dom": "^18.0.0" } }, "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,9 @@
     "@tailwindcss/postcss": "^4.1.8",
     "next": "15.3.3",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "leaflet": "^1.9.4",
+    "react-leaflet": "^4.2.1"
   },
   "devDependencies": {
     "@types/node": "^22.15.30",


### PR DESCRIPTION
## Summary
- add `leaflet` and `react-leaflet` dependencies
- create dynamic `MapClient` component
- show map on suggestion detail page

## Testing
- `go build ./...`
- `go test ./...`
- `bun install` *(fails: 403)*
- `bun run build` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_684969b8f6ac832f845c17e2af2b34ce