### PR TITLE
[Potarin] Add leaflet map to suggestion detail

### DIFF
--- a/frontend/app/components/MapClient.tsx
+++ b/frontend/app/components/MapClient.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { MapContainer, TileLayer, Marker, Polyline, Popup } from "react-leaflet";
+import "leaflet/dist/leaflet.css";
+import { Route } from "potarin-shared/types";
+
+function LeafletMap({ routes }: { routes: Route[] }) {
+  const center: [number, number] =
+    routes.length > 0
+      ? [routes[0].position.lat, routes[0].position.lng]
+      : [0, 0];
+  const positions = routes.map((r) => [r.position.lat, r.position.lng]) as [
+    number,
+    number,
+  ][];
+
+  return (
+    <MapContainer center={center} zoom={13} className="h-96 w-full">
+      <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+      {positions.length > 1 && <Polyline positions={positions} />}
+      {routes.map((r, idx) => (
+        <Marker
+          key={idx}
+          position={[r.position.lat, r.position.lng] as [number, number]}
+        >
+          <Popup>
+            <strong>{r.title}</strong> - {r.description}
+          </Popup>
+        </Marker>
+      ))}
+    </MapContainer>
+  );
+}
+
+export default dynamic(() => Promise.resolve(LeafletMap), { ssr: false });

--- a/frontend/app/suggestions/[id]/page.tsx
+++ b/frontend/app/suggestions/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { Detail, Suggestion } from "potarin-shared/types";
+import MapClient from "../../components/MapClient";
 
 async function getSuggestions(): Promise<Suggestion[]> {
   const res = await fetch(
@@ -45,6 +46,9 @@ export default async function SuggestionDetail({
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-4">{detail.summary}</h1>
+      <div className="mb-4">
+        <MapClient routes={detail.routes} />
+      </div>
       <ul className="space-y-2">
         {detail.routes.map((r, index) => (
           <li key={index} className="border p-2 rounded">

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -5,11 +5,14 @@
       "name": "potarin-frontend",
       "dependencies": {
         "@tailwindcss/postcss": "^4.1.8",
+        "leaflet": "^1.9.4",
         "next": "15.3.3",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "react-leaflet": "^5.0.0",
       },
       "devDependencies": {
+        "@types/leaflet": "^1.9.18",
         "@types/node": "^22.15.30",
         "@types/react": "^19.1.7",
         "autoprefixer": "10.4.21",
@@ -142,6 +145,8 @@
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
 
+    "@react-leaflet/core": ["@react-leaflet/core@3.0.0", "", { "peerDependencies": { "leaflet": "^1.9.0", "react": "^19.0.0", "react-dom": "^19.0.0" } }, "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ=="],
+
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
     "@rushstack/eslint-patch": ["@rushstack/eslint-patch@1.11.0", "", {}, "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ=="],
@@ -184,9 +189,13 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
+
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
+
+    "@types/leaflet": ["@types/leaflet@1.9.18", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-ht2vsoPjezor5Pmzi5hdsA7F++v5UGq9OlUduWHmMZiuQGIpJ2WS5+Gg9HaAA79gNh1AIPtCqhzejcIZ3lPzXQ=="],
 
     "@types/node": ["@types/node@22.15.30", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA=="],
 
@@ -562,6 +571,8 @@
 
     "language-tags": ["language-tags@1.0.9", "", { "dependencies": { "language-subtag-registry": "^0.3.20" } }, "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA=="],
 
+    "leaflet": ["leaflet@1.9.4", "", {}, "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="],
+
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
     "lightningcss": ["lightningcss@1.30.1", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-darwin-arm64": "1.30.1", "lightningcss-darwin-x64": "1.30.1", "lightningcss-freebsd-x64": "1.30.1", "lightningcss-linux-arm-gnueabihf": "1.30.1", "lightningcss-linux-arm64-gnu": "1.30.1", "lightningcss-linux-arm64-musl": "1.30.1", "lightningcss-linux-x64-gnu": "1.30.1", "lightningcss-linux-x64-musl": "1.30.1", "lightningcss-win32-arm64-msvc": "1.30.1", "lightningcss-win32-x64-msvc": "1.30.1" } }, "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg=="],
@@ -679,6 +690,8 @@
     "react-dom": ["react-dom@19.1.0", "", { "dependencies": { "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.0" } }, "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g=="],
 
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "react-leaflet": ["react-leaflet@5.0.0", "", { "dependencies": { "@react-leaflet/core": "^3.0.0" }, "peerDependencies": { "leaflet": "^1.9.0", "react": "^19.0.0", "react-dom": "^19.0.0" } }, "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,18 +10,21 @@
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.1.8",
+    "leaflet": "^1.9.4",
     "next": "15.3.3",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "react-leaflet": "^5.0.0"
   },
   "devDependencies": {
+    "@types/leaflet": "^1.9.18",
     "@types/node": "^22.15.30",
     "@types/react": "^19.1.7",
     "autoprefixer": "10.4.21",
+    "eslint": "^9.28.0",
+    "eslint-config-next": "^15.3.3",
     "postcss": "8.5.4",
     "tailwindcss": "4.1.8",
-    "typescript": "5.8.3",
-    "eslint": "^9.28.0",
-    "eslint-config-next": "^15.3.3"
+    "typescript": "5.8.3"
   }
 }


### PR DESCRIPTION
## Summary
- add react-leaflet and leaflet dependencies
- create MapClient for client-side map rendering
- render MapClient on suggestion detail page

## Testing
- `go build ./...`
- `go test ./...`
- `bun install`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_6849727b7b98832f8a817439e26ac661