### PR TITLE
[Potarin] add fiber backend hot reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Tailwind CSS
 
 ### ビルド・開発
 
-Bun (フロント用) / Go modules
+Bun (フロント用) / Go modules + Air (ホットリロード)
 
 ### デプロイ
 
@@ -64,11 +64,12 @@ ChatGPT (Codex/Custom GPT)
 
 ## クイックスタート
 
-1. `backend` ディレクトリで Go サーバーを起動
+1. `backend` をホットリロード起動 (Air を利用)
 
 ```bash
+go install github.com/cosmtrek/air@latest # 初回のみ
 cd backend
-go run .
+air
 ```
 
 2. 別ターミナルで `frontend` を起動

--- a/backend/.air.toml
+++ b/backend/.air.toml
@@ -1,0 +1,10 @@
+# Config file for Air - https://github.com/cosmtrek/air
+root = "."
+
+[build]
+  cmd = "go build -o ./tmp/main ."
+  bin = "./tmp/main"
+  include_ext = ["go"]
+  exclude_dir = ["tmp"]
+  exclude_file = ["*_test.go"]
+  delay = 1000


### PR DESCRIPTION
## Summary
- add Air config for hot reloading the Go server
- document how to use Air in the backend quickstart
- note Air in the build/dev stack

## Testing
- `go build ./...`
- `go test ./...`
- `bun install`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_684a9d8e99c0832f85c578f37af93b80