### PR TITLE
[Potarin] Fix duplicate suggestion keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 .next/
 **/.env.local
+backend/tmp

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,5 +1,6 @@
 import { Suggestion } from "potarin-shared/types";
 import Link from "next/link";
+import { ensureUniqueIds } from "../lib/ensureUniqueIds";
 
 async function getSuggestions(): Promise<Suggestion[]> {
   const res = await fetch(
@@ -14,7 +15,7 @@ async function getSuggestions(): Promise<Suggestion[]> {
 }
 
 export default async function Home() {
-  const suggestions = await getSuggestions();
+  const suggestions = ensureUniqueIds(await getSuggestions());
 
   return (
     <div className="p-4">

--- a/frontend/app/suggestions/[id]/page.tsx
+++ b/frontend/app/suggestions/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { Detail, Suggestion } from "potarin-shared/types";
+import { ensureUniqueIds } from "../../../lib/ensureUniqueIds";
 
 async function getSuggestions(): Promise<Suggestion[]> {
   const res = await fetch(
@@ -36,7 +37,7 @@ export default async function SuggestionDetail({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const suggestions = await getSuggestions();
+  const suggestions = ensureUniqueIds(await getSuggestions());
   const suggestion = suggestions.find((s) => s.id === id);
   if (!suggestion) {
     throw new Error("Suggestion not found");

--- a/frontend/lib/ensureUniqueIds.ts
+++ b/frontend/lib/ensureUniqueIds.ts
@@ -1,0 +1,14 @@
+import { randomUUID } from 'crypto';
+import { Suggestion } from 'potarin-shared/types';
+
+export function ensureUniqueIds(suggestions: Suggestion[]): Suggestion[] {
+  const used = new Set<string>();
+  return suggestions.map((s) => {
+    let id = s.id;
+    if (!id || used.has(id)) {
+      id = randomUUID();
+    }
+    used.add(id);
+    return { ...s, id };
+  });
+}


### PR DESCRIPTION
## Summary
- assign unique IDs in suggestions
- use new helper when loading suggestions

## Testing
- `go build ./...`
- `go test ./...`
- `bun install`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_684a9efa5208832fafa16661e01bcf70