### PR TITLE
[Potarin] Update CI Go version to stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.x"
+          go-version: "stable"
       - run: go build ./...
       - run: go test ./...
 


### PR DESCRIPTION
## Summary
- use `go-version: "stable"` in CI

## Testing
- `go build ./...`
- `go test ./...`
- `bun install`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_684aaba08870832f8a58bcb6f71f8c18