### PR TITLE
[Potarin] read openai model from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ bun run dev
 
 環境変数 `NEXT_PUBLIC_API_URL` を設定すると、フロントエンドが参照する API サーバー URL を変更できます。
 バックエンドで OpenAI を利用する場合は、プロジェクトルートの `.env.local` に `OPENAI_API_KEY` を設定してください。
+利用するモデルを変更したい場合は、`OPENAI_MODEL` にモデル名を指定します。未設定時は `gpt-4o-mini` が使用されます。
 
 ## 現在の機能
 

--- a/backend/internal/openai.go
+++ b/backend/internal/openai.go
@@ -49,6 +49,17 @@ type chatResponse struct {
 	} `json:"choices"`
 }
 
+const fallbackModel = "gpt-4o-mini"
+
+// GetModel returns the chat model defined in the environment or a default.
+func GetModel() string {
+	m := os.Getenv("OPENAI_MODEL")
+	if m == "" {
+		return fallbackModel
+	}
+	return m
+}
+
 // LoadEnv loads environment variables from .env.local if present.
 func LoadEnv() {
 	if err := godotenv.Load(".env.local"); err != nil {

--- a/backend/internal/openai_test.go
+++ b/backend/internal/openai_test.go
@@ -63,3 +63,17 @@ func TestNewClientEmptyKey(t *testing.T) {
 
 	}
 }
+
+func TestGetModelFromEnv(t *testing.T) {
+	t.Setenv("OPENAI_MODEL", "test-model")
+	if got := GetModel(); got != "test-model" {
+		t.Fatalf("expected 'test-model', got %q", got)
+	}
+}
+
+func TestGetModelFallback(t *testing.T) {
+	t.Setenv("OPENAI_MODEL", "")
+	if got := GetModel(); got != "gpt-4o-mini" {
+		t.Fatalf("expected fallback 'gpt-4o-mini', got %q", got)
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -79,7 +79,7 @@ func fetchSuggestions(ctx context.Context, ai AIClient, userPrompt string) ([]sh
 		userPrompt = "今日は天気が良いので、3つの異なるサイクリングコースを提案してください。日付とその季節を考慮してください 本日は六月です"
 	}
 	req := internal.ChatRequest{
-		Model: "gpt-4o",
+		Model: internal.GetModel(),
 		Messages: []internal.Message{
 			{
 				Role: "system",
@@ -120,7 +120,7 @@ func fetchSuggestions(ctx context.Context, ai AIClient, userPrompt string) ([]sh
 func fetchDetail(ctx context.Context, ai AIClient, suggestion shared.Suggestion) (shared.Detail, error) {
 	userPrompt := fmt.Sprintf("タイトル: %s\n説明: %s\nこのコースの詳細を教えてください。", suggestion.Title, suggestion.Description)
 	req := internal.ChatRequest{
-		Model: "gpt-4o",
+		Model: internal.GetModel(),
 		Messages: []internal.Message{
 			{Role: "system", Content: "Return course detail as JSON."},
 			{Role: "user", Content: userPrompt},


### PR DESCRIPTION
## Summary
- choose chat model via `OPENAI_MODEL` env var
- default to `gpt-4o-mini` when undefined
- document the new variable in README
- add tests for the env model logic

## Testing
- `go build ./...`
- `go test ./...`
- `bun install`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_684ab0246a08832fa182868ba10c3558