### PR TITLE
[Potarin] Add map visualization with React-Leaflet

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ bun run dev
 - `/api/v1/suggestions` で AI によるコース提案を取得
 - `POST /api/v1/details` でコースの詳細 (summary とルート情報) を取得
 - Next.js フロントエンドで提案一覧と詳細ページを表示
+- React-Leaflet でルートを地図描画
 
 ## 今後の予定
 
-- 地図描画機能 (React-Leaflet)
 - ユーザー現在地連携や履歴保存などの拡張
 
 ### 設計・実装の注意点

--- a/frontend/app/suggestions/[id]/MapClient.tsx
+++ b/frontend/app/suggestions/[id]/MapClient.tsx
@@ -1,0 +1,51 @@
+"use client";
+import dynamic from "next/dynamic";
+import "leaflet/dist/leaflet.css";
+import { Route } from "potarin-shared/types";
+
+const MapContainer = dynamic(
+  () => import("react-leaflet").then((m) => m.MapContainer),
+  { ssr: false },
+) as any;
+const TileLayer = dynamic(
+  () => import("react-leaflet").then((m) => m.TileLayer),
+  { ssr: false },
+) as any;
+const Marker = dynamic(
+  () => import("react-leaflet").then((m) => m.Marker),
+  { ssr: false },
+) as any;
+const Popup = dynamic(
+  () => import("react-leaflet").then((m) => m.Popup),
+  { ssr: false },
+) as any;
+
+export default function MapClient({ routes }: { routes: Route[] }) {
+  if (!routes || routes.length === 0) return null;
+  const center: [number, number] = [
+    routes[0].position.lat,
+    routes[0].position.lng,
+  ];
+
+  return (
+    <MapContainer
+      center={center}
+      zoom={13}
+      style={{ height: "400px", width: "100%" }}
+    >
+      <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+      {routes.map((r, i) => (
+        <Marker
+          key={i}
+          position={[r.position.lat, r.position.lng] as [number, number]}
+        >
+          <Popup>
+            <strong>{r.title}</strong>
+            <br />
+            {r.description}
+          </Popup>
+        </Marker>
+      ))}
+    </MapContainer>
+  );
+}

--- a/frontend/app/suggestions/[id]/page.tsx
+++ b/frontend/app/suggestions/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { Detail, Suggestion } from "potarin-shared/types";
 import { ensureUniqueIds } from "../../../lib/ensureUniqueIds";
+import MapClient from "./MapClient";
 
 async function getSuggestions(): Promise<Suggestion[]> {
   const res = await fetch(
@@ -47,6 +48,9 @@ export default async function SuggestionDetail({
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-4">{detail.summary}</h1>
+      <div className="mb-4 h-96">
+        <MapClient routes={detail.routes} />
+      </div>
       <ul className="space-y-2">
         {detail.routes.map((r, index) => (
           <li key={index} className="border p-2 rounded">

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -5,9 +5,11 @@
       "name": "potarin-frontend",
       "dependencies": {
         "@tailwindcss/postcss": "^4.1.8",
+        "leaflet": "^1.9.4",
         "next": "15.3.3",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "react-leaflet": "^5.0.0",
       },
       "devDependencies": {
         "@types/node": "^22.15.30",
@@ -141,6 +143,8 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
+
+    "@react-leaflet/core": ["@react-leaflet/core@3.0.0", "", { "peerDependencies": { "leaflet": "^1.9.0", "react": "^19.0.0", "react-dom": "^19.0.0" } }, "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ=="],
 
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
@@ -562,6 +566,8 @@
 
     "language-tags": ["language-tags@1.0.9", "", { "dependencies": { "language-subtag-registry": "^0.3.20" } }, "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA=="],
 
+    "leaflet": ["leaflet@1.9.4", "", {}, "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="],
+
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
     "lightningcss": ["lightningcss@1.30.1", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-darwin-arm64": "1.30.1", "lightningcss-darwin-x64": "1.30.1", "lightningcss-freebsd-x64": "1.30.1", "lightningcss-linux-arm-gnueabihf": "1.30.1", "lightningcss-linux-arm64-gnu": "1.30.1", "lightningcss-linux-arm64-musl": "1.30.1", "lightningcss-linux-x64-gnu": "1.30.1", "lightningcss-linux-x64-musl": "1.30.1", "lightningcss-win32-arm64-msvc": "1.30.1", "lightningcss-win32-x64-msvc": "1.30.1" } }, "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg=="],
@@ -679,6 +685,8 @@
     "react-dom": ["react-dom@19.1.0", "", { "dependencies": { "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.0" } }, "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g=="],
 
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "react-leaflet": ["react-leaflet@5.0.0", "", { "dependencies": { "@react-leaflet/core": "^3.0.0" }, "peerDependencies": { "leaflet": "^1.9.0", "react": "^19.0.0", "react-dom": "^19.0.0" } }, "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,9 +10,11 @@
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.1.8",
+    "leaflet": "^1.9.4",
     "next": "15.3.3",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "react-leaflet": "^5.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.15.30",


### PR DESCRIPTION
## Summary
- add React Leaflet and Leaflet packages
- implement `MapClient` to draw route markers on a map
- show map on suggestion detail page
- document the new map feature in README

## Testing
- `go build ./...`
- `go test ./...`
- `bun install`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_684ab151132c832fa3ca7587724940ef