### PR TITLE
[Potarin] add user location integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,13 @@ bun run dev
 
 - `/api/v1/suggestions` で AI によるコース提案を取得
 - `POST /api/v1/details` でコースの詳細 (summary とルート情報) を取得
+- `POST /api/v1/location` でユーザー現在地を送信してプロンプトに反映
 - Next.js フロントエンドで提案一覧と詳細ページを表示
 - React-Leaflet でルートを地図描画
 
 ## 今後の予定
 
-- ユーザー現在地連携や履歴保存などの拡張
+- 履歴保存などの拡張
 
 ### 設計・実装の注意点
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -15,11 +15,12 @@ import (
 )
 
 type UserProfile struct {
-	Name        string   `json:"name"`
-	Location    string   `json:"location"`
-	BikeType    string   `json:"bikeType"`
-	Level       string   `json:"level"`
-	Preferences []string `json:"preferences"`
+	Name        string          `json:"name"`
+	Location    string          `json:"location"`
+	BikeType    string          `json:"bikeType"`
+	Level       string          `json:"level"`
+	Preferences []string        `json:"preferences"`
+	Position    shared.Position `json:"position"`
 }
 
 // ユーザープロフィールのサンプルデータ
@@ -29,6 +30,7 @@ var userProfile = UserProfile{
 	BikeType:    "クロスバイク",
 	Level:       "初心者",
 	Preferences: []string{"海沿い", "自然", "カフェ"},
+	Position:    shared.Position{},
 }
 
 func main() {
@@ -64,6 +66,16 @@ func main() {
 			return fiber.NewError(fiber.StatusInternalServerError, err.Error())
 		}
 		return c.JSON(detail)
+	})
+
+	app.Post("/api/v1/location", func(c *fiber.Ctx) error {
+		var pos shared.Position
+		if err := c.BodyParser(&pos); err != nil {
+			return fiber.NewError(fiber.StatusBadRequest, err.Error())
+		}
+		userProfile.Position = pos
+		userProfile.Location = fmt.Sprintf("%f,%f", pos.Lat, pos.Lng)
+		return c.SendStatus(fiber.StatusOK)
 	})
 
 	log.Println("server listening on :8080")

--- a/frontend/app/GeoUpdater.tsx
+++ b/frontend/app/GeoUpdater.tsx
@@ -1,0 +1,25 @@
+"use client";
+import { useEffect } from "react";
+
+export default function GeoUpdater() {
+  useEffect(() => {
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition((pos) => {
+        fetch(
+          `${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080"}/api/v1/location`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              lat: pos.coords.latitude,
+              lng: pos.coords.longitude,
+            }),
+          },
+        ).catch(() => {
+          // ignore errors
+        });
+      });
+    }
+  }, []);
+  return null;
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,6 @@
 import "./styles/globals.css";
 import Link from "next/link";
+import GeoUpdater from "./GeoUpdater";
 
 export const metadata = {
   title: "Potarin",
@@ -13,6 +14,7 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body>
+        <GeoUpdater />
         <header className="p-4 bg-gray-100 mb-4">
           <Link href="/" className="font-bold">
             Potarin


### PR DESCRIPTION
## Summary
- send geolocation from frontend using navigator API
- store coordinates via new `/api/v1/location` endpoint
- embed location in user profile for AI prompts
- document location feature in README

## Testing
- `go build ./...`
- `go test ./...`
- `bun install`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_684ab378c49c832f8f9ac55725dad330